### PR TITLE
Support new PAC (0.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Support for new PAC (0.5)
+
 ## [v1.2.0] - 2022-11-22
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ name = "rp2040_monotonic"
 [dependencies]
 rtic-monotonic = "1.0.0"
 fugit = "0.3.0"
-rp2040-pac = ">=0.2.0,<0.5"
+rp2040-pac = ">=0.2.0,<0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ impl Monotonic for Rp2040Monotonic {
     }
 
     fn clear_compare_flag(&mut self) {
-        self.timer.intr.modify(|_, w| w.alarm_0().set_bit());
+        self.timer.intr.modify(|_, w| w.alarm_0().bit(true));
     }
 
     fn zero() -> Self::Instant {


### PR DESCRIPTION
One small change, needed to work with the latest PAC.

I haven't checked yet if this is backwards compatible though, so the `>= 0.2.0` part of the dependency may not be correct anymore.